### PR TITLE
build(Makefile) add support for test files

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,13 +26,17 @@ SOURCES_WITH_HEADERS = \
 	src/drivers/avr_w5100.c\
 	external/w5100/w5100.c
 
-MAIN_FILE = src/main.c
-
+ifndef TEST
 SOURCES =\
-	$(MAIN_FILE)\
+	src/main.c\
 	$(SOURCES_WITH_HEADERS)
 
-# blink.c
+else
+SOURCES =\
+	src/test/$(TEST).c\
+	$(SOURCES_WITH_HEADERS)
+
+endif
 
 HEADERS = \
 	$(SOURCES_WITH_HEADERS:.c=.h) \


### PR DESCRIPTION
Add the feature to pass the TEST argument to the
Makefile to compile a test .c code instead of the
main c file.

eg. make TEST=test_web_server, this compiles the
file src/test/test_web_server.c instead of
src/main.c (which is still the default if make is
called without defining TEST)

files:Makefile